### PR TITLE
Refs #17906: Use 1.15+ boilerplate code

### DIFF
--- a/lib/smart_proxy_dns_plugin_template/dns_plugin_template_main.rb
+++ b/lib/smart_proxy_dns_plugin_template/dns_plugin_template_main.rb
@@ -17,53 +17,25 @@ module Proxy::Dns::PluginTemplate
       super('localhost', dns_ttl)
     end
 
-    # Calls to these methods are guaranteed to have non-nil parameters
-    def create_a_record(fqdn, ip)
-      case a_record_conflicts(fqdn, ip) #returns -1, 0, 1
-        when 1
-          raise(Proxy::Dns::Collision, "'#{fqdn} 'is already in use")
-        when 0 then
-          return nil
-        else
-          # FIXME: add a forward 'A' record with fqdn, ip
+    def do_create(name, value, type)
+      # FIXME: There is no trailing dot. Your backend might require it.
+      if false
+        name += '.'
+        value += '.' if ['PTR', 'CNAME'].include?(type)
       end
+
+      # FIXME: Create a record with the correct name, value and type
+      raise Proxy::Dns::Error.new("Failed to point #{name} to #{value} with type #{type}")
     end
 
-    def create_aaaa_record(fqdn, ip)
-      case aaaa_record_conflicts(fqdn, ip) #returns -1, 0, 1
-        when 1
-          raise(Proxy::Dns::Collision, "'#{fqdn} 'is already in use")
-        when 0 then
-          return nil
-        else
-          # FIXME: add a forward 'AAAA' record with fqdn, ip
+    def do_remove(name, type)
+      # FIXME: There is no trailing dot. Your backend might require it.
+      if false
+        name += '.'
       end
-    end
 
-    def create_ptr_record(fqdn, ptr)
-      case ptr_record_conflicts(fqdn, ptr_to_ip(ptr)) #returns -1, 0, 1
-        when 1
-          raise(Proxy::Dns::Collision, "'#{fqdn} 'is already in use")
-        when 0 then
-          return nil
-        else
-          # FIXME: add a reverse 'PTR' record with ip, fqdn
-      end
-    end
-
-    def remove_a_record(fqdn)
-      raise Proxy::Dns::NotFound.new("Cannot find DNS entry for #{fqdn}") unless dns_find(fqdn)
-      # FIXME: remove the forward 'A' record with fqdn
-    end
-
-    def remove_aaaa_record(fqdn)
-      raise Proxy::Dns::NotFound.new("Cannot find DNS entry for #{fqdn}") unless dns_find(fqdn)
-      # FIXME: remove the forward 'AAAA' record with fqdn
-    end
-
-    def remove_ptr_record(ip)
-      raise Proxy::Dns::NotFound.new("Cannot find DNS entry for #{ip}") unless dns_find(ip)
-      # FIXME: remove the reverse 'PTR' record with ip
+      # FIXME: Remove a record with the correct name and type
+      raise Proxy::Dns::Error.new("Failed to remove #{name} of type #{type}")
     end
   end
 end

--- a/lib/smart_proxy_dns_plugin_template/dns_plugin_template_plugin.rb
+++ b/lib/smart_proxy_dns_plugin_template/dns_plugin_template_plugin.rb
@@ -9,7 +9,7 @@ module Proxy::Dns::PluginTemplate
     # Settings not listed under default_settings are considered optional and by default have nil value.
     default_settings :required_setting => 'default_value', :required_path => '/must/exist'
 
-    requires :dns, '>= 1.13'
+    requires :dns, '>= 1.15'
 
     # Verifies that a file exists and is readable.
     # Uninitialized optional settings will not trigger validation errors.

--- a/test/dns_plugin_template_record_test.rb
+++ b/test/dns_plugin_template_record_test.rb
@@ -7,100 +7,76 @@ class DnsPluginTemplateRecordTest < Test::Unit::TestCase
     @provider = Proxy::Dns::PluginTemplate::Record.new('required_value', 'a_value', '/required/path', '/some/path', 999)
   end
 
-  # Test that a missing :example_setting throws an error
+  # These tests are very verbose and possibly a lot of duplication, but it is a
+  # somewhat complete overview of the possible inputs.
+
   # Test A record creation
   def test_create_a
     # Use mocha to expect any calls to backend services to prevent creating real records
-    #   MyService.expects(:create).with(:ip => '10.1.1.1', :name => 'test.example.com').returns(true)
-    @provider.expects(:a_record_conflicts).with('test.example.com', '10.1.1.1').returns(-1)
-    assert @provider.create_a_record('test.example.com', '10.1.1.1')
-  end
-
-  # Test A record creation fails if the record exists
-  def test_create_a_conflict
-    # Use mocha to expect any calls to backend services to prevent creating real records
-    #   MyService.expects(:create).with(:ip => '10.1.1.1', :name => 'test.example.com').returns(false)
-    @provider.expects(:a_record_conflicts).with('test.example.com', '10.1.1.1').returns(1)
-    assert_raise(Proxy::Dns::Collision) { @provider.create_a_record('test.example.com', '10.1.1.1') }
+    #   MyService.expects(:create_address_v4).with(:value => '10.1.1.1', :name => 'test.example.com').returns(true)
+    assert @provider.do_create('test.example.com', '10.1.1.1', 'A')
   end
 
   # Test AAAA record creation
   def test_create_aaaa
     # Use mocha to expect any calls to backend services to prevent creating real records
-    #   MyService.expects(:create).with(:ip => '2001:db8::1', :name => 'test.example.com').returns(true)
-    @provider.expects(:aaaa_record_conflicts).with('test.example.com', '2001:db8::1').returns(-1)
-    assert @provider.create_aaaa_record('test.example.com', '2001:db8::1')
+    #   MyService.expects(:create_address_v6).with(:value => '2001:db8::1', :name => 'test.example.com').returns(true)
+    assert @provider.do_create('test.example.com', '2001:db8::1', 'AAAA')
   end
 
-  # Test AAAA record creation fails if the record exists
-  def test_create_aaaa_conflict
+  # Test PTR record creation with an IPv4 address
+  def test_create_ptr_v4
     # Use mocha to expect any calls to backend services to prevent creating real records
-    #   MyService.expects(:create).with(:ip => '2001:db8::1', :name => 'test.example.com').returns(false)
-    @provider.expects(:aaaa_record_conflicts).with('test.example.com', '2001:db8::1').returns(1)
-    assert_raise(Proxy::Dns::Collision) { @provider.create_aaaa_record('test.example.com', '2001:db8::1') }
+    #   MyService.expects(:create_reverse).with(:value => 'test.example.com', :name => '3.2.1.10.in-addr.arpa').returns(true)
+    assert @provider.do_create('3.2.1.10.in-addr.arpa', 'test.example.com', 'PTR')
   end
 
-  # Test PTR record creation
-  def test_create_ptr
+  # Test PTR record creation with an IPv6 address
+  def test_create_ptr_v6
     # Use mocha to expect any calls to backend services to prevent creating real records
-    #   MyService.expects(:create_reverse).with(:ip => '10.1.1.1', :name => 'test.example.com').returns(true)
-    @provider.expects(:ptr_record_conflicts).with('test.example.com', '10.1.1.1').returns(-1)
-    assert @provider.create_ptr_record('test.example.com', '1.1.1.10.in-addr.arpa')
+    #   MyService.expects(:create_reverse).with(:value => 'test.example.com', :name => '1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa').returns(true)
+    assert @provider.do_create('1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa', 'test.example.com', 'PTR')
   end
 
-  # Test PTR record creation fails if the record exists
-  def test_create_ptr_conflict
+  # Test CNAME record creation
+  def test_create_cname
     # Use mocha to expect any calls to backend services to prevent creating real records
-    #   MyService.expects(:create_reverse).with(:ip => '10.1.1.1', :name => 'test.example.com').returns(false)
-    @provider.expects(:ptr_record_conflicts).with('test.example.com', '10.1.1.1').returns(1)
-    assert_raise(Proxy::Dns::Collision) { @provider.create_ptr_record('test.example.com', '1.1.1.10.in-addr.arpa') }
+    #   MyService.expects(:create_cname).with(:value => 'target.example.com', :name => 'test.example.com').returns(true)
+    assert @provider.do_create('test.example.com', 'target.example.com', 'CNAME')
   end
 
   # Test A record removal
   def test_remove_a
     # Use mocha to expect any calls to backend services to prevent deleting real records
-    #   MyService.expects(:delete).with(:name => 'test.example.com').returns(true)
-    @provider.expects(:dns_find).with('test.example.com').returns(true)
-    assert @provider.remove_a_record('test.example.com')
-  end
-
-  # Test A record removal fails if the record doesn't exist
-  def test_remove_a_not_found
-    # Use mocha to expect any calls to backend services to prevent deleting real records
-    #   MyService.expects(:delete).with(:name => 'test.example.com').returns(false)
-    @provider.expects(:dns_find).with('test.example.com').returns(false)
-    assert_raise(Proxy::Dns::NotFound) { assert @provider.remove_a_record('test.example.com') }
+    #   MyService.expects(:delete_address_v4).with(:name => 'test.example.com').returns(true)
+    assert @provider.do_remove('test.example.com', 'A')
   end
 
   # Test AAAA record removal
   def test_remove_aaaa
     # Use mocha to expect any calls to backend services to prevent deleting real records
-    #   MyService.expects(:delete).with(:name => 'test.example.com').returns(true)
-    @provider.expects(:dns_find).with('test.example.com').returns(true)
-    assert @provider.remove_aaaa_record('test.example.com')
+    #   MyService.expects(:delete_address_v6).with(:name => 'test.example.com').returns(true)
+    assert @provider.do_remove('test.example.com', 'AAAA')
   end
 
-  # Test AAAA record removal fails if the record doesn't exist
-  def test_remove_aaaa_not_found
+  # Test PTR record removal with an IPv4 address
+  def test_remove_ptr_v4
     # Use mocha to expect any calls to backend services to prevent deleting real records
-    #   MyService.expects(:delete).with(:name => 'test.example.com').returns(false)
-    @provider.expects(:dns_find).with('test.example.com').returns(false)
-    assert_raise(Proxy::Dns::NotFound) { assert @provider.remove_aaaa_record('test.example.com') }
+    #   MyService.expects(:delete_reverse).with(:name => '3.2.1.10.in-addr.arpa').returns(true)
+    assert @provider.do_remove('3.2.1.10.in-addr.arpa', 'PTR')
   end
 
-  # Test PTR record removal
-  def test_remove_ptr
+  # Test PTR record removal with an IPv6 address
+  def test_remove_ptr_v6
     # Use mocha to expect any calls to backend services to prevent deleting real records
-    #   MyService.expects(:delete).with(:ip => '10.1.1.1').returns(true)
-    @provider.expects(:dns_find).with('10.1.1.1').returns(true)
-    assert @provider.remove_ptr_record('10.1.1.1')
+    #   MyService.expects(:delete_reverse).with(:name => '1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa').returns(true)
+    assert @provider.do_remove('1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa', 'PTR')
   end
 
-  # Test PTR record removal fails if the record doesn't exist
-  def test_remove_ptr_not_found
+  # Test CNAME record removal
+  def test_remove_cname
     # Use mocha to expect any calls to backend services to prevent deleting real records
-    #   MyService.expects(:delete).with(:ip => '10.1.1.1').returns(false)
-    @provider.expects(:dns_find).with('10.1.1.1').returns(false)
-    assert_raise(Proxy::Dns::NotFound) { assert @provider.remove_ptr_record('10.1.1.1') }
+    #   MyService.expects(:delete_cname).with(:name => 'test.example.com').returns(true)
+    assert @provider.do_remove('test.example.com', 'CNAME')
   end
 end


### PR DESCRIPTION
https://github.com/theforeman/smart-proxy/pull/492 adds the boilerplate to the smart proxy. This reduces the need for it to be copied into each plugin.