### PR TITLE
Remove external tools deps and make safer

### DIFF
--- a/rename.rb
+++ b/rename.rb
@@ -30,18 +30,20 @@ if snake == camel
 end
 
 old_dirs = []
-Find.find('.') do |path|
+Find.find(File.dirname(__FILE__)) do |path|
   next unless File.file?(path)
   next if path =~ /\.git/
   next if path == './rename.rb'
 
   # Change content on all files
-  system(%(sed 's/dns_plugin_template/#{snake}/g' -i #{path} ))
-  system(%(sed 's/DnsPluginTemplate/#{camel}/g'   -i #{path} ))
-  system(%(sed 's/PluginTemplate/#{camel.sub(/\ADns/, '')}/g'   -i #{path} ))
+  buffer = File.read(path)
+  buffer.gsub!(/dns_plugin_template/, snake)
+  buffer.gsub!(/DnsPluginTemplate/, camel)
+  buffer.gsub!(/PluginTemplate/, camel.sub(/\ADns/, '') )
+  File.open(path, "w") {|file| file.puts buffer }
 end
 
-Find.find('.') do |path|
+Find.find(File.dirname(__FILE__)) do |path|
   # Change all the paths to the new snake_case name
   if path =~ /dns_plugin_template/i
     new = path.gsub('dns_plugin_template', snake)


### PR DESCRIPTION
Running system()-calls to 'sed' is not portable. Some systems have
BSD-sed, and others GNU-sed. These do not accept similar options.
Replaced the system calls with ruby-equivalentish (not stream-editing,
but good enough for this purpose since we control the input files sizes).

Also added a safeguard on the find(). Now we make sure that the
find()-command is run in the expected directory with \_\_FILE\_\_ and not
working-directory, which can be anything.